### PR TITLE
Add main attribute to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "title": "Van11y accessible tab panel system using ARIA",
   "name": "van11y-accessible-tab-panel-aria",
   "description": "ES2015 accessible tabs panel system, using ARIA (compatible IE9+ when transpiled)",
+  "main": "dist/van11y-accessible-tab-panel-aria.min.js",
   "version": "1.0.0",
   "keywords": [
     "Accessibility",
@@ -46,5 +47,4 @@
     "gulp-uglify": "^1.4.2",
     "gulp-header": "^1.7.1"
   }
-  
 }


### PR DESCRIPTION
Add main attribute to package.json to define the entry point to the module. This means the module can be be loaded via Browserify/Webpack when used an as npm dependency.